### PR TITLE
Fix a couple of fields for the goodreads export mapping templates

### DIFF
--- a/backend/app/services/data_import.py
+++ b/backend/app/services/data_import.py
@@ -836,7 +836,10 @@ PREDEFINED_MAPPINGS: list[dict[str, Any]] = [
             },
             "language": {"source": "", "transform": None},
             "tags": {"source": "Bookshelves", "transform": None},
-            "notes": {"source": "My Review", "transform": None},
+            "notes": {
+                "source": "My Review", 
+                "transform": "value.replace('<br/>', '\n') if value else None",
+            },
             "blurb": {"source": "", "transform": None},
             "rating": {
                 "source": "My Rating",
@@ -846,7 +849,7 @@ PREDEFINED_MAPPINGS: list[dict[str, Any]] = [
                 "source": "Exclusive Shelf",
                 "transform": (
                     "shelf_map = {'to-read': 'want_to_read', "
-                    "'currently-reading': 'currently_reading', 'read': 'read'}\n"
+                    "'currently-reading': 'currently_reading', 'read': 'read', 'did-not-finish': 'did_not_finish'}\n"
                     "status = shelf_map.get(value.strip().lower(), 'want_to_read')\n"
                     "return status"
                 ),


### PR DESCRIPTION
I imported +700 books with these couple of fixes:

- add books to did-not-finish from the recent dnf shelf on goodreads.
- convert br to newlines on reviews.