### PR TITLE
Goodreads import fix, custom docs domain and isbn uniqueness fix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -100,6 +100,10 @@ jobs:
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${VERSION}"
           printf '{"version":"%s","release_url":"%s"}\n' "$VERSION" "$RELEASE_URL" > ./dist/version.json
 
+      - name: Write CNAME
+        run: |
+          printf 'docs.librislog.app\n' > ./dist/CNAME
+
       - uses: peaceiris/actions-gh-pages@v4
         if: steps.check-release-docs.outputs.has_docs == 'true'
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,6 +163,7 @@ jobs:
     permissions:
       checks: write
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -219,7 +219,8 @@ jobs:
           fail-on-error: "false"
 
       - name: Post PR comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         uses: actions/github-script@v9
         env:
           backend_passed:     ${{ steps.backend.outputs.passed }}

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # LibrisLog
 
 <p align="center">
-  <a href="https://codebude.github.io/librislog/">📚 Full Documentation</a>
+  <a href="https://docs.librislog.app/">📚 Full Documentation</a>
   &nbsp;·&nbsp;
-  <a href="https://codebude.github.io/librislog/guide/getting-started">Quick Start</a>
+  <a href="https://docs.librislog.app/guide/getting-started">Quick Start</a>
   &nbsp;·&nbsp;
-  <a href="https://codebude.github.io/librislog/api/">API Reference</a>
+  <a href="https://docs.librislog.app/api/">API Reference</a>
   &nbsp;·&nbsp;
-  <a href="https://codebude.github.io/librislog/next/">Nightly Docs</a>
+  <a href="https://docs.librislog.app/next/">Nightly Docs</a>
 </p>
 
 <p align="center">
   <a href="https://github.com/codebude/librislog/actions/workflows/tests.yml"><img src="https://github.com/codebude/librislog/actions/workflows/tests.yml/badge.svg" alt="Tests"></a>
   <a href="https://github.com/codebude?tab=packages&repo_name=librislog"><img src="https://github.com/codebude/librislog/actions/workflows/docker.yml/badge.svg" alt="Docker Build"></a>
-  <a href="https://codebude.github.io/librislog/"><img src="https://github.com/codebude/librislog/actions/workflows/docs.yml/badge.svg" alt="Docs Build"></a>
+  <a href="https://docs.librislog.app/"><img src="https://github.com/codebude/librislog/actions/workflows/docs.yml/badge.svg" alt="Docs Build"></a>
   <img src="https://img.shields.io/badge/python-3.14-%233776AB?logo=python" alt="Python">
   <img src="https://img.shields.io/badge/svelte-5-%23FF3E00?logo=svelte" alt="Svelte">
   <img src="https://img.shields.io/badge/FastAPI-0.136-%23009688?logo=fastapi" alt="FastAPI">
@@ -91,7 +91,7 @@ Open **http://localhost:8001** and create your account.
 
 The backend is a standalone FastAPI application. The full API is documented via Swagger UI at `/api/docs` when the server is running.
 
-Create API keys from the web UI (Profile → API Keys) for headless access. See the [API Reference](https://codebude.github.io/librislog/api/) for details.
+Create API keys from the web UI (Profile → API Keys) for headless access. See the [API Reference](https://docs.librislog.app/api/) for details.
 
 ```bash
 cd backend
@@ -117,7 +117,7 @@ uv run uvicorn app.main:app --reload
 
 ## Contributing
 
-See the [Developer Setup](https://codebude.github.io/librislog/guide/developer-setup) guide for instructions on running LibrisLog locally, running tests, and using the CLI tool.
+See the [Developer Setup](https://docs.librislog.app/guide/developer-setup) guide for instructions on running LibrisLog locally, running tests, and using the CLI tool.
 
 This project was developed with the assistance of AI coding tools under a human-supervised workflow. No AI-generated code is committed without human review and approval.
 

--- a/backend/alembic/versions/f7e9d1c3b5a2_make_isbn_unique_per_user.py
+++ b/backend/alembic/versions/f7e9d1c3b5a2_make_isbn_unique_per_user.py
@@ -1,0 +1,69 @@
+"""make isbn unique per user instead of globally
+
+Revision ID: f7e9d1c3b5a2
+Revises: 86fa9b4f6d61
+Create Date: 2026-06-08 07:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f7e9d1c3b5a2"
+down_revision: Union[str, Sequence[str], None] = "86fa9b4f6d61"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _recreate_book_table(conn, *, global_unique: bool) -> None:
+    """Recreate the book table with either a global or per-user ISBN unique constraint."""
+    old_cols = []
+    for col in sa.inspect(conn).get_columns("book"):
+        old_cols.append(col)
+
+    col_names = [c["name"] for c in old_cols]
+    pk_cols = [c["name"] for c in old_cols if c.get("primary_key")]
+    pk_name = pk_cols[0] if pk_cols else "id"
+
+    col_defs = []
+    for c in old_cols:
+        typ = str(c["type"])
+        nullable = "NOT NULL" if not c.get("nullable", True) else ""
+        col_defs.append(f"  {c['name']} {typ} {nullable}".strip())
+
+    extras = [f"PRIMARY KEY ({pk_name})"]
+    for fk in sa.inspect(conn).get_foreign_keys("book"):
+        extras.append(
+            f"FOREIGN KEY({fk['constrained_columns'][0]}) REFERENCES {fk['referred_table']}({fk['referred_columns'][0]})"
+        )
+    extras.append("UNIQUE (isbn)" if global_unique else "UNIQUE (user_id, isbn)")
+
+    col_list = ", ".join(col_names)
+    extra_sql = ",\n  ".join(extras)
+
+    sql = f"""CREATE TABLE book__new (
+  {',\n  '.join(col_defs)},
+  {extra_sql}
+)"""
+    conn.execute(sa.text(sql))
+    conn.execute(sa.text(f"INSERT INTO book__new ({col_list}) SELECT {col_list} FROM book"))
+
+    for idx in sa.inspect(conn).get_indexes("book"):
+        idx_name = idx["name"]
+        if idx_name:
+            cols = ", ".join(idx["column_names"])
+            unique = "UNIQUE " if idx.get("unique") else ""
+            conn.execute(sa.text(f"CREATE {unique}INDEX IF NOT EXISTS {idx_name} ON book__new ({cols})"))
+
+    conn.execute(sa.text("DROP TABLE book"))
+    conn.execute(sa.text("ALTER TABLE book__new RENAME TO book"))
+
+
+def upgrade() -> None:
+    _recreate_book_table(op.get_bind(), global_unique=False)
+
+
+def downgrade() -> None:
+    _recreate_book_table(op.get_bind(), global_unique=True)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -54,11 +54,15 @@ class UserRole(str, Enum):
 class Book(SQLModel, table=True):
     """A book in the user's library."""
 
+    __table_args__ = (
+        sa.UniqueConstraint("user_id", "isbn", name="uq_book_user_id_isbn"),
+    )
+
     id: Optional[int] = Field(default=None, primary_key=True)
     title: str = Field(index=True)
     subtitle: Optional[str] = None
     author: str = Field(default="", index=True)
-    isbn: Optional[str] = Field(default=None, unique=True)
+    isbn: Optional[str] = Field(default=None)
     cover_url: Optional[str] = None
     publisher: Optional[str] = None
 

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -124,7 +124,7 @@ def _normalize_language(language: str | None) -> str | None:
 def _raise_integrity_conflict(exc: IntegrityError) -> None:
     """Convert ISBN unique-constraint violations to HTTP 409."""
     message = str(exc.orig).lower() if exc.orig else str(exc).lower()
-    if "book.isbn" in message and "unique" in message:
+    if ("book.isbn" in message or "uq_book_user_id_isbn" in message) and "unique" in message:
         raise HTTPException(status_code=409, detail="This ISBN is already used by another book.") from exc
     raise
 

--- a/backend/app/routers/import_.py
+++ b/backend/app/routers/import_.py
@@ -27,7 +27,7 @@ router = APIRouter(prefix="/api/import", tags=["import"])
 def _raise_integrity_conflict(exc: IntegrityError) -> None:
     """Convert ISBN unique-constraint violations to HTTP 409."""
     message = str(exc.orig).lower() if exc.orig else str(exc).lower()
-    if "book.isbn" in message and "unique" in message:
+    if ("book.isbn" in message or "uq_book_user_id_isbn" in message) and "unique" in message:
         raise HTTPException(status_code=409, detail="This ISBN is already used by another book.") from exc
     raise
 

--- a/backend/app/services/data_import.py
+++ b/backend/app/services/data_import.py
@@ -836,7 +836,10 @@ PREDEFINED_MAPPINGS: list[dict[str, Any]] = [
             },
             "language": {"source": "", "transform": None},
             "tags": {"source": "Bookshelves", "transform": None},
-            "notes": {"source": "My Review", "transform": None},
+            "notes": {
+                "source": "My Review", 
+                "transform": "value.replace('<br/>', '\n') if value else None",
+            },
             "blurb": {"source": "", "transform": None},
             "rating": {
                 "source": "My Rating",
@@ -846,7 +849,7 @@ PREDEFINED_MAPPINGS: list[dict[str, Any]] = [
                 "source": "Exclusive Shelf",
                 "transform": (
                     "shelf_map = {'to-read': 'want_to_read', "
-                    "'currently-reading': 'currently_reading', 'read': 'read'}\n"
+                    "'currently-reading': 'currently_reading', 'read': 'read', 'did-not-finish': 'did_not_finish'}\n"
                     "status = shelf_map.get(value.strip().lower(), 'want_to_read')\n"
                     "return status"
                 ),

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -991,6 +991,84 @@ def test_suggest_user_isolation(client: TestClient, create_user_with_key: Callab
         assert resp2.json()["suggestions"] == []
 
 
+# ── user data isolation ────────────────────────────────────────────────────────
+
+def test_same_isbn_allowed_for_different_users(client: TestClient, create_user_with_key: Callable[..., tuple[User, str]]) -> None:
+    """ISBN uniqueness is per-user — two users can each have the same ISBN."""
+
+    shared_isbn = "9780441013593"
+
+    # Create book with a shared ISBN for User 1 (default admin)
+    book1 = _create_book(client, title="Dune", author="Frank Herbert", page_count=412, isbn=shared_isbn)
+
+    # Create second user and their book with the same ISBN
+    user2, key2 = create_user_with_key(email="other@example.com")
+    with TestClient(client.app) as c2:
+        c2.headers.update({"X-API-Key": key2})
+        resp = c2.post("/api/books", json={
+            "title": "Dune", "author": "Frank Herbert", "page_count": 412, "isbn": shared_isbn,
+        })
+        assert resp.status_code == 201
+        book2 = resp.json()
+
+    # ── list ──
+    list1 = client.get("/api/books").json()
+    assert len(list1["books"]) == 1
+    assert list1["books"][0]["id"] == book1["id"]
+
+    with TestClient(client.app) as c2:
+        c2.headers.update({"X-API-Key": key2})
+        list2 = c2.get("/api/books").json()
+        assert len(list2["books"]) == 1
+        assert list2["books"][0]["id"] == book2["id"]
+
+    # ── get by id (own) ──
+    assert client.get(f"/api/books/{book1['id']}").status_code == 200
+
+    with TestClient(client.app) as c2:
+        c2.headers.update({"X-API-Key": key2})
+        assert c2.get(f"/api/books/{book2['id']}").status_code == 200
+
+    # ── get by id (other user) ──
+    assert client.get(f"/api/books/{book2['id']}").status_code == 404
+
+    with TestClient(client.app) as c2:
+        c2.headers.update({"X-API-Key": key2})
+        assert c2.get(f"/api/books/{book1['id']}").status_code == 404
+
+    # ── update (other user) ──
+    assert client.patch(f"/api/books/{book2['id']}", json={"title": "Hacked"}).status_code == 404
+
+    with TestClient(client.app) as c2:
+        c2.headers.update({"X-API-Key": key2})
+        assert c2.patch(f"/api/books/{book1['id']}", json={"title": "Hacked"}).status_code == 404
+
+    # ── delete (other user) ──
+    assert client.delete(f"/api/books/{book2['id']}").status_code == 404
+
+    with TestClient(client.app) as c2:
+        c2.headers.update({"X-API-Key": key2})
+        assert c2.delete(f"/api/books/{book1['id']}").status_code == 404
+
+    # ── stats isolation ──
+    stats1 = client.get("/api/books/stats").json()
+    assert stats1["total_books"] == 1
+
+    with TestClient(client.app) as c2:
+        c2.headers.update({"X-API-Key": key2})
+        stats2 = c2.get("/api/books/stats").json()
+        assert stats2["total_books"] == 1
+
+    # ── suggestions isolation ──
+    resp1 = client.get("/api/books/suggestions/authors?q=Frank")
+    assert resp1.json()["suggestions"] == ["Frank Herbert"]
+
+    with TestClient(client.app) as c2:
+        c2.headers.update({"X-API-Key": key2})
+        resp2 = c2.get("/api/books/suggestions/authors?q=Frank")
+        assert resp2.json()["suggestions"] == ["Frank Herbert"]
+
+
 # ── prevent removing date_finished for read books ──────────────────────────────
 
 def test_update_book_rejects_clearing_date_finished_for_read(client: TestClient) -> None:

--- a/docs/.vitepress/config.base.ts
+++ b/docs/.vitepress/config.base.ts
@@ -27,7 +27,7 @@ export default defineConfig({
   },
   head: [
     ['link', { rel: 'icon', href: '/favicon.svg' }],
-    ['script', { defer: '', 'data-domain': 'codebude.github.io/librislog', src: 'https://plausible.code-bude.net/js/script.js' }],
+    ['script', { defer: '', 'data-domain': 'docs.librislog.app', src: 'https://plausible.code-bude.net/js/script.js' }],
   ],
   themeConfig: {
     logo: '/logo.png',

--- a/docs/.vitepress/config.nightly.ts
+++ b/docs/.vitepress/config.nightly.ts
@@ -3,17 +3,17 @@ import baseConfig from './config.base'
 
 export default defineConfig({
   ...baseConfig,
-  base: '/librislog/next/',
+  base: '/next/',
   head: [
     ...(baseConfig.head || []),
-    ['link', { rel: 'icon', href: '/librislog/next/favicon.svg', type: 'image/svg+xml' }],
-    ['link', { rel: 'alternate icon', href: '/librislog/next/favicon.ico', sizes: 'any' }],
+    ['link', { rel: 'icon', href: '/next/favicon.svg', type: 'image/svg+xml' }],
+    ['link', { rel: 'alternate icon', href: '/next/favicon.ico', sizes: 'any' }],
   ],
   themeConfig: {
     ...baseConfig.themeConfig,
     nav: [
       ...(baseConfig.themeConfig?.nav || []),
-      { text: 'Release Docs', link: 'https://codebude.github.io/librislog/' },
+      { text: 'Release Docs', link: 'https://docs.librislog.app/' },
     ],
   },
 })

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,17 +3,17 @@ import baseConfig from './config.base'
 
 export default defineConfig({
   ...baseConfig,
-  base: '/librislog/',
+  base: '/',
   head: [
     ...(baseConfig.head || []),
-    ['link', { rel: 'icon', href: '/librislog/favicon.svg', type: 'image/svg+xml' }],
-    ['link', { rel: 'alternate icon', href: '/librislog/favicon.ico', sizes: 'any' }],
+    ['link', { rel: 'icon', href: '/favicon.svg', type: 'image/svg+xml' }],
+    ['link', { rel: 'alternate icon', href: '/favicon.ico', sizes: 'any' }],
   ],
   themeConfig: {
     ...baseConfig.themeConfig,
     nav: [
       ...(baseConfig.themeConfig?.nav || []),
-      { text: 'Nightly Docs', link: 'https://codebude.github.io/librislog/next/' },
+      { text: 'Nightly Docs', link: 'https://docs.librislog.app/next/' },
     ],
   },
 })

--- a/docs/guide/developer-setup.md
+++ b/docs/guide/developer-setup.md
@@ -116,8 +116,8 @@ Output goes to `docs/.vitepress/dist/`.
 ### Nightly Docs
 
 The CI workflow publishes two doc sets on every push to `develop`:
-- **Release docs** at `https://codebude.github.io/librislog/` — built from the latest git tag
-- **Nightly docs** at `https://codebude.github.io/librislog/next/` — built from `develop`
+- **Release docs** at `https://docs.librislog.app/` — built from the latest git tag
+- **Nightly docs** at `https://docs.librislog.app/next/` — built from `develop`
 
 The nightly build uses a separate config (`config.nightly.ts`) which sets a different base path and swaps the nav link to point back to the release docs.
 

--- a/frontend/src/lib/stores/updateCheck.test.ts
+++ b/frontend/src/lib/stores/updateCheck.test.ts
@@ -3,7 +3,7 @@ import { isNewer, checkForUpdate } from './updateCheck';
 
 vi.mock('$lib/version', () => ({ version: 'v1.0.0', gitSha: 'abc1234' }));
 
-const CHECK_URL = 'https://codebude.github.io/librislog/version.json';
+const CHECK_URL = 'https://docs.librislog.app/version.json';
 const STORAGE_KEY = 'librislog_update_check';
 
 function mockFetch(data: unknown, ok = true) {

--- a/frontend/src/lib/stores/updateCheck.ts
+++ b/frontend/src/lib/stores/updateCheck.ts
@@ -7,7 +7,7 @@ export interface UpdateInfo {
 
 const STORAGE_KEY = 'librislog_update_check';
 const CACHE_TTL = 60 * 60 * 1000;
-const CHECK_URL = 'https://codebude.github.io/librislog/version.json';
+const CHECK_URL = 'https://docs.librislog.app/version.json';
 
 function parseVersion(v: string): { parts: number[]; isPreRelease: boolean } {
 	const segments = v.replace(/^v/, '').split(/[.-]/);


### PR DESCRIPTION
This pull request implements a significant change to ISBN uniqueness, making it enforced per user rather than globally, and migrates all documentation URLs and related configuration from the old GitHub Pages domain to the new custom domain `docs.librislog.app`. It also improves test coverage for user data isolation, updates analytics and version check endpoints, and makes minor workflow and import improvements.

**Book ISBN uniqueness and user data isolation:**

* The `Book` model and database schema now enforce ISBN uniqueness per user instead of globally. This is achieved by adding a composite unique constraint on `(user_id, isbn)` and updating the migration logic to handle the transition both forwards and backwards. Error handling for unique constraint violations is updated accordingly. [[1]](diffhunk://#diff-6e605393bbb0b2f9bc5a4c9205a27d6219095b8f91b2c012568e9c2b5701a12cR1-R69) [[2]](diffhunk://#diff-96c5a7997e3d147589c1d6cac9cf36730df0fe459ae0170a2fc90ededd63fed2R57-R65) [[3]](diffhunk://#diff-14e1c2cc9060e1f7c81aa4086da79e304c4d44d337e407a5b607c975bb79deb6L127-R127) [[4]](diffhunk://#diff-f6a8d59fb4d6a517fdf20453c7431323684b1718cfdfe5dafa7883a90216babdL30-R30)
* Added comprehensive tests to ensure that two users can each have a book with the same ISBN, and that all book operations (list, get, update, delete, stats, suggestions) are properly isolated by user.

**Documentation and site domain migration:**

* All documentation links, badges, and references in `README.md`, developer guides, and frontend/backend configs are updated to use `https://docs.librislog.app/` (and `/next/` for nightly docs) instead of the old `codebude.github.io/librislog` URLs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R94) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-R120) [[4]](diffhunk://#diff-40441b2a5424f65fe0fa9dbcf2fcbc5bb0b05ebaff1ce9bb2002fb186a4f8ce4L119-R120) [[5]](diffhunk://#diff-c8f96df5f8bcfb4f616a0999b1d33eab1d6c367715a779ca05c15781ec43daa4L6-R6) [[6]](diffhunk://#diff-005e504c785dba8640feb06e2605323089e25d8eafb22cb9a2fd69fb8f542d13L10-R10)
* Documentation site configuration (`docs/.vitepress`) is updated for the new domain, including analytics, base paths, and navigation links. [[1]](diffhunk://#diff-8b9428cfe721ce22fb0e6046c71d04d065a81903972005334a587ab587ed2987L30-R30) [[2]](diffhunk://#diff-20b9df71fca006a469216cd43f79f0e15dd40958c0e75155152c57aa1121d844L6-R16) [[3]](diffhunk://#diff-3def678deb1b1d5a53948eb8491817dde4dc881e032e785fc61cc93d334eefcdL6-R16)
* The docs build workflow now writes a `CNAME` file to support the custom domain.

**Workflow and CI improvements:**

* The tests workflow now grants `issues: write` permission and only posts PR comments if the PR originates from the same repository, avoiding errors on forks. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR166) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL221-R223)

**Import and data handling improvements:**

* The Goodreads import now correctly transforms review notes to preserve line breaks, and recognizes the "did-not-finish" shelf as a valid status. [[1]](diffhunk://#diff-05fa713eb73905d5870543d424d3965ee987aaffe7bf6b48bfb748a9307697f4L839-R842) [[2]](diffhunk://#diff-05fa713eb73905d5870543d424d3965ee987aaffe7bf6b48bfb748a9307697f4L849-R852)